### PR TITLE
fix: serialize geofence identifiers as JSONArray

### DIFF
--- a/android/src/main/kotlin/dev/locus/receiver/GeofenceBroadcastReceiver.kt
+++ b/android/src/main/kotlin/dev/locus/receiver/GeofenceBroadcastReceiver.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
 import dev.locus.LocusPlugin
 import dev.locus.service.HeadlessService
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -43,7 +44,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val payload = JSONObject().apply {
             try {
                 put("action", action)
-                put("identifiers", ids)
+                put("identifiers", JSONArray(ids))
                 event.triggeringLocation?.let { loc ->
                     val location = JSONObject().apply {
                         put("latitude", loc.latitude)


### PR DESCRIPTION
## Problem

`GeofenceBroadcastReceiver.onReceive()` passes a Kotlin `List<String>` to `JSONObject.put("identifiers", ids)`. `JSONObject.put()` does not auto-convert Kotlin collections to `JSONArray`, so downstream `GeofenceEventProcessor.optJSONArray("identifiers")` returns `null` for 100% of geofence events.

## Fix

Wrap the list: `put("identifiers", JSONArray(ids))`

## Impact

Without this fix, all geofence event identifiers are lost — every event arrives with `identifier: "unknown"` on the Dart side.