### PR TITLE
fix(android): foreground service stuck on "Starting..." (OS restart + startForeground/notify race)

### DIFF
--- a/android/src/main/kotlin/dev/locus/service/ForegroundService.kt
+++ b/android/src/main/kotlin/dev/locus/service/ForegroundService.kt
@@ -160,11 +160,24 @@ class ForegroundService : Service() {
             }
         } else {
             Log.e(TAG, "Attempted to start foreground service with null intent or extras.")
+            // We already promoted to foreground with the placeholder above; remove it
+            // so it can't linger after we stop.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(Service.STOP_FOREGROUND_REMOVE)
+            } else {
+                @Suppress("DEPRECATION")
+                stopForeground(true)
+            }
             stopSelf(startId)
             return START_NOT_STICKY
         }
 
-        return START_STICKY
+        // Use REDELIVER_INTENT so that when the OS recreates the service after a
+        // low-memory kill it redelivers the original intent (with the notification
+        // config in extras) instead of a null intent. With START_STICKY the restart
+        // arrives with a null intent, the notification config is lost, and the
+        // service is left stuck on the "Starting…" placeholder before stopping itself.
+        return START_REDELIVER_INTENT
     }
 
     @TargetApi(26)
@@ -206,7 +219,7 @@ class ForegroundService : Service() {
      * Called when the user swipes the task away from the recents screen. The default
      * behavior on many OEMs (notably Samsung One UI and Xiaomi MIUI) is to stop the
      * associated service; we override with a no-op so that tracking survives task
-     * removal. Combined with [START_STICKY] in [onStartCommand] and the soft-detach
+     * removal. Combined with [START_REDELIVER_INTENT] in [onStartCommand] and the soft-detach
      * path in `LocusPlugin.onDetachedFromEngine`, this upholds the documented
      * `stopOnTerminate:false + foregroundService:true` always-on contract.
      *

--- a/android/src/main/kotlin/dev/locus/service/ForegroundService.kt
+++ b/android/src/main/kotlin/dev/locus/service/ForegroundService.kt
@@ -136,29 +136,10 @@ class ForegroundService : Service() {
         val extras = intent?.extras
         val notificationId = extras?.getInt("id", DEFAULT_NOTIFICATION_ID) ?: DEFAULT_NOTIFICATION_ID
 
-        // Immediately promote to foreground with a minimal notification.
-        // This MUST happen as fast as possible to avoid the 5-second
-        // ForegroundServiceDidNotStartInTimeException on Android 14+.
-        promoteToForeground(notificationId, buildMinimalNotification())
-
-        if (extras != null) {
-            // Save for dynamic updates
-            lastExtras = Bundle(extras)
-            lastNotificationId = notificationId
-
-            try {
-                // Build the full notification and update it in place.
-                val fullNotification = buildNotification(applicationContext, extras)
-                if (fullNotification != null) {
-                    getSystemService(NotificationManager::class.java)
-                        ?.notify(notificationId, fullNotification)
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to build full notification, keeping minimal: ${e.message}")
-                // Service is already in foreground with the minimal notification,
-                // so the OS won't kill us.
-            }
-        } else {
+        if (extras == null) {
+            // Must still call startForeground once to satisfy the
+            // startForegroundService() contract before stopping.
+            promoteToForeground(notificationId, buildMinimalNotification())
             Log.e(TAG, "Attempted to start foreground service with null intent or extras.")
             // We already promoted to foreground with the placeholder above; remove it
             // so it can't linger after we stop.
@@ -171,6 +152,27 @@ class ForegroundService : Service() {
             stopSelf(startId)
             return START_NOT_STICKY
         }
+
+        // Save for dynamic updates
+        lastExtras = Bundle(extras)
+        lastNotificationId = notificationId
+
+        // Build the full notification BEFORE promoting to foreground and post it
+        // in a single startForeground call. The previous two-step —
+        // startForeground(minimal) then notify(full) — races: the notification
+        // passed to startForeground is posted asynchronously by system_server and
+        // can land after the app-side notify(), clobbering the full notification
+        // and leaving the "Starting..." placeholder stuck. Building the
+        // notification is fast (no I/O), so the 5-second
+        // ForegroundServiceDidNotStartInTimeException window on Android 14+ —
+        // measured from startForegroundService() — is still comfortably met.
+        val notification = try {
+            buildNotification(applicationContext, extras)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to build full notification, using minimal: ${e.message}")
+            null
+        } ?: buildMinimalNotification()
+        promoteToForeground(notificationId, notification)
 
         // Use REDELIVER_INTENT so that when the OS recreates the service after a
         // low-memory kill it redelivers the original intent (with the notification


### PR DESCRIPTION
## Description

Fixes two independent ways the foreground service ends up stuck on the
**"Starting..."** placeholder notification:

**1. OS restart with `START_STICKY` (tracking dies).** When Android kills the
service under memory pressure and later recreates it, `START_STICKY` delivers a
**null intent**. The notification config lives in the intent extras, so the service
can't rebuild its notification, logs *"Attempted to start foreground service with
null intent or extras"*, and stops itself — after already posting the placeholder.
Background tracking silently dies until the app is reopened.
Fix: return `START_REDELIVER_INTENT` so the OS redelivers the original intent
(extras included) on recreate, and clear the foreground notification in the
null-intent guard so the placeholder can never linger.

**2. `startForeground(minimal)` / `notify(full)` race (~50% on a normal start).**
The notification passed to `startForeground()` is posted **asynchronously by
system_server**, while the follow-up `notify(id, full)` posts directly from the app
process. When the system's deferred post lands after the app's `notify()`, the
minimal placeholder overwrites the full notification and stays for the life of the
service (tracking still works underneath). Verified on a physical device:
`dumpsys notification` shows the live record with `android.title=String (Starting...)`
and the fallback icon while logcat shows no build failure and the delivered intent
has extras.
Fix: build the full notification from the extras **first** and hand it directly to
`startForeground`, so the id is posted exactly once — no racing `notify()`. The
minimal placeholder remains only as a fallback (build failure, or the null-intent
stop path, which must still call `startForeground` once to satisfy the
`startForegroundService()` contract). The Android 14+ 5-second
`ForegroundServiceDidNotStartInTimeException` window is unaffected: it is measured
from `startForegroundService()`, and building a `Notification` from a `Bundle` is
milliseconds of work.

Closes #52

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / Documentation / Refactor

## Native Changes

- [x] Android (Java/Gradle)
- [ ] iOS (Swift/Podspec)
- [ ] Dart/Flutter only

## Testing Checklist

- [x] `flutter analyze` passes
- [x] `flutter test` passes (Unit Tests)
- [ ] `cd example && flutter build apk --debug` (Android Build)
- [ ] `cd example && flutter build ios --no-codesign --debug` (iOS Build)
- [ ] Verified on physical device (required for background/geolocation testing) —
  *both defects were diagnosed/captured on a physical device (diagnostics below);
  on-device verification of the fix is in progress in the consuming app and this
  checklist will be updated when complete*

## Screenshots / Diagnostics

Stuck state captured on a physical device (Samsung, Android 15) while the service
was healthy and the delivered intent had extras — i.e. the race, not a build
failure:

```
$ adb shell dumpsys activity services dev.locus
    isForeground=true foregroundId=197812504 ...
    Delivered Starts:
    #0 id=1 ... intent=Intent { ... dev.locus.service.ForegroundService (has extras) }

$ adb shell dumpsys notification --noredact | grep -A60 197812504 | grep android.title
                android.title=String (Starting...)
```

Logcat contains no `Failed to build full notification` and no
`Attempted to start foreground service with null intent or extras`.

## Checklist

- [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
