### PR TITLE
Fix AGP/Kotlin classloader mismatch in Android build

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -17,8 +17,14 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:9.3.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.10")
+        // Pinned to match the current Flutter plugin ecosystem baseline (e.g.
+        // permission_handler_android 14.0.0) instead of a version pair that
+        // diverges from consuming apps' own AGP/Kotlin plugin pins — the
+        // mismatch loads AndroidLibrarySourceSet from two different
+        // classloaders and fails with a ClassCastException at sync time.
+        // See https://github.com/weorbis/locus/issues/57
+        classpath("com.android.tools.build:gradle:9.0.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #57.

`android/build.gradle.kts` self-pins `com.android.tools.build:gradle:9.3.1` / `kotlin-gradle-plugin:2.4.10` in its `buildscript` block. When a consuming app pins a different (older, but currently ecosystem-baseline) AGP/Kotlin version — e.g. `9.0.1`/`2.3.20`, the same pair `permission_handler_android` 14.0.0 uses — Gradle loads `LibraryExtension`/`AndroidLibrarySourceSet` from two different classloaders, and the build fails with:

```
class com.android.build.gradle.internal.api.DefaultAndroidSourceSet_Decorated cannot be cast to class com.android.build.api.dsl.AndroidLibrarySourceSet
```

## Change

Pin `android/build.gradle.kts`'s `buildscript` classpath to `com.android.tools.build:gradle:9.0.1` and `kotlin-gradle-plugin:2.3.20`, matching the current baseline used elsewhere in the Flutter plugin ecosystem, instead of a version pair that can diverge from consuming apps.

## Testing

Verified in a real Flutter app (AGP 9.0.1, Kotlin 2.3.20, Gradle 9.1.0 pinned at the root): build failed with the `ClassCastException` before this change, builds and runs cleanly (tested end-to-end on a physical Android device, confirmed live location data flowing through `Locus.location.stream`) after it.