### PR TITLE
chore(release): prepare v2.4.1

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -13,14 +13,18 @@ doc/api/
 ios/.symlinks/
 example/ios/Pods/
 example/ios/Podfile.lock
+example/ios/Flutter/Flutter.podspec
 example/ios/Flutter/Generated.xcconfig
 example/ios/Flutter/flutter_export_environment.sh
 example/ios/Flutter/ephemeral/
 example/ios/Runner/GeneratedPluginRegistrant.*
+example/ios/**/xcshareddata/swiftpm/
 
 # Android/Gradle artifacts
+android/gradle/
 example/android/.gradle/
 example/android/local.properties
+example/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
 
 # IDE/editor junk
 .DS_Store
@@ -37,4 +41,5 @@ CLAUDE.md
 GEMINI.md
 .github/
 doc/roadmap/
+/docs/
 .spec-workflow/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [2.4.1] - 2026-08-23
 
+### Changed
+
+- **Tooling: current SDK version surfaces now share `pubspec.yaml` as their enforced source** — Dart and CLI consumers use one generated internal constant, native builds and release automation read the pubspec directly, and CI checks current documentation for drift.
+
 ### Fixed
 
 - **Android: host AGP/Kotlin mismatches no longer create duplicate Gradle classloaders (#57)** — The Android module now inherits both build plugins from the consuming Flutter app instead of pinning private copies that can fail with cross-classloader `ClassCastException`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Android: host AGP/Kotlin mismatches no longer create duplicate Gradle classloaders (#57)** — The Android module now inherits both build plugins from the consuming Flutter app instead of pinning private copies that can fail with cross-classloader `ClassCastException`s.
+
 ## [2.4.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-08-22
+
 ### Fixed
 
 - **Android: host AGP/Kotlin mismatches no longer create duplicate Gradle classloaders (#57)** — The Android module now inherits both build plugins from the consuming Flutter app instead of pinning private copies that can fail with cross-classloader `ClassCastException`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [2.4.1] - 2026-08-22
+## [2.4.1] - 2026-08-23
 
 ### Fixed
 
 - **Android: host AGP/Kotlin mismatches no longer create duplicate Gradle classloaders (#57)** — The Android module now inherits both build plugins from the consuming Flutter app instead of pinning private copies that can fail with cross-classloader `ClassCastException`s.
+- **Android: immediate sync no longer drops live location payloads (#56)** — Non-batched auto-sync now preserves the nested `coords` payload produced by the location and geofence pipelines instead of treating it as a flat SQLite record and silently returning without an HTTP request.
 
 ## [2.4.0] - 2026-08-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ When adding or updating dependencies:
 
 1. Bump `version:` in `pubspec.yaml`.
 2. Run `dart run tool/sync_version.dart` to propagate the new version to the
-   Dart constants (`lib/src/config/geolocation_config.dart` and `bin/*.dart`).
+   shared Dart constant and current-version documentation.
 3. Update `CHANGELOG.md`.
 4. Commit and push to `main`. CI tags `v<version>`, creates the GitHub
    release, and the package is then published manually with
@@ -87,8 +87,10 @@ When adding or updating dependencies:
 Native build files (`android/build.gradle.kts`, `ios/locus.podspec`) derive
 the version from `pubspec.yaml` automatically — no manual sync needed.
 
-CI runs `dart run tool/sync_version.dart --check` on every PR; if the Dart
-constants drift from `pubspec.yaml`, the build fails before merge.
+CI runs `dart run tool/sync_version.dart --check` on every PR; if a generated
+constant or current-version documentation surface drifts from `pubspec.yaml`,
+the build fails before merge. Historical changelog entries and generated lock
+files remain owned by their release and dependency workflows.
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For full documentation, visit the [Locus GitHub repository](https://github.com/w
 
 ```yaml
 dependencies:
-  locus: ^2.4.0
+  locus: ^2.4.1
 ```
 
 ### 2. Basic Setup
@@ -143,9 +143,9 @@ dart run locus:migrate --dry-run
 
 ## Versioning
 
-- Current release: **v2.4.0**
+- Current release: **v2.4.1**
 - Supports Flutter 3.x / Dart 3.x
-- See [CHANGELOG.md](CHANGELOG.md#240---2026-08-16) for release details
+- See [CHANGELOG.md](CHANGELOG.md#241---2026-08-22) for release details
 
 ## Tree Shaking
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ dart run locus:migrate --dry-run
 
 - Current release: **v2.4.1**
 - Supports Flutter 3.x / Dart 3.x
-- See [CHANGELOG.md](CHANGELOG.md#241---2026-08-22) for release details
+- See [CHANGELOG.md](CHANGELOG.md#241---2026-08-23) for release details
 
 ## Tree Shaking
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ dart run locus:migrate --dry-run
 
 - Current release: **v2.4.1**
 - Supports Flutter 3.x / Dart 3.x
-- See [CHANGELOG.md](CHANGELOG.md#241---2026-08-23) for release details
+- See [CHANGELOG.md](CHANGELOG.md) for release details
 
 ## Tree Shaking
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -11,17 +11,6 @@ version = file("../pubspec.yaml").readText()
     ?.groupValues?.get(1)?.trim()
     ?: error("Could not parse `version:` from pubspec.yaml")
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle:9.3.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.10")
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -29,6 +18,9 @@ allprojects {
     }
 }
 
+// Android and Kotlin plugin versions belong to the consuming Flutter app.
+// Local classpath pins create incompatible duplicate plugin types when the
+// host uses a different supported toolchain.
 apply(plugin = "com.android.library")
 apply(plugin = "org.jetbrains.kotlin.android")
 extensions.configure<LibraryExtension>("android") {

--- a/bin/doctor.dart
+++ b/bin/doctor.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:locus/src/cli/ios_permission_macros.dart';
 
-const _version = '2.4.0';
+const _version = '2.4.1';
 
 void main(List<String> args) async {
   final parser = ArgParser()

--- a/bin/doctor.dart
+++ b/bin/doctor.dart
@@ -18,8 +18,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:locus/src/cli/ios_permission_macros.dart';
-
-const _version = '2.4.1';
+import 'package:locus/src/version.dart';
 
 void main(List<String> args) async {
   final parser = ArgParser()
@@ -43,7 +42,7 @@ void main(List<String> args) async {
   }
 
   if (results['help'] as bool) {
-    stdout.writeln('Locus Doctor v$_version');
+    stdout.writeln('Locus Doctor v$locusVersion');
     stdout.writeln('');
     stdout.writeln('Diagnoses Locus configuration and platform setup issues.');
     stdout.writeln('');
@@ -54,7 +53,7 @@ void main(List<String> args) async {
   }
 
   if (results['version'] as bool) {
-    stdout.writeln(_version);
+    stdout.writeln(locusVersion);
     exit(0);
   }
 

--- a/bin/locus.dart
+++ b/bin/locus.dart
@@ -20,7 +20,7 @@ import 'package:args/command_runner.dart';
 
 import 'src/commands/migrate_command.dart';
 
-const _version = '2.4.0';
+const _version = '2.4.1';
 
 class LocusCLI extends CommandRunner<void> {
   LocusCLI() : super('locus', 'Locus SDK CLI - v$_version') {

--- a/bin/locus.dart
+++ b/bin/locus.dart
@@ -17,13 +17,12 @@ library;
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:locus/src/version.dart';
 
 import 'src/commands/migrate_command.dart';
 
-const _version = '2.4.1';
-
 class LocusCLI extends CommandRunner<void> {
-  LocusCLI() : super('locus', 'Locus SDK CLI - v$_version') {
+  LocusCLI() : super('locus', 'Locus SDK CLI - v$locusVersion') {
     argParser.addFlag(
       'version',
       abbr: 'v',
@@ -51,7 +50,7 @@ class SetupPlaceholderCommand extends Command<void> {
   Future<void> run() async {
     if (argResults?['help'] as bool? ?? false) {
       stdout.writeln('''
-Locus Setup v$_version
+Locus Setup v$locusVersion
 
 Configure native permissions and dependencies for Locus SDK.
 
@@ -92,7 +91,7 @@ class DoctorPlaceholderCommand extends Command<void> {
   Future<void> run() async {
     if (argResults?['help'] as bool? ?? false) {
       stdout.writeln('''
-Locus Doctor v$_version
+Locus Doctor v$locusVersion
 
 Diagnose configuration and platform issues with Locus SDK.
 
@@ -124,14 +123,14 @@ Future<void> main(List<String> args) async {
 
   try {
     if (args.length == 1 && (args.first == '--version' || args.first == '-v')) {
-      stdout.writeln(_version);
+      stdout.writeln(locusVersion);
       exit(0);
     }
 
     if (args.isEmpty || args.first == '--help' || args.first == '-h') {
       stdout.writeln('''
 ╔══════════════════════════════════════════════════════════════╗
-║                    Locus SDK CLI v$_version                     ║
+║                    Locus SDK CLI v$locusVersion                     ║
 ╠══════════════════════════════════════════════════════════════╣
 ║  A battle-tested background geolocation SDK for Flutter      ║
 ╠══════════════════════════════════════════════════════════════╣

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -19,8 +19,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:locus/src/cli/ios_permission_macros.dart';
-
-const _version = '2.4.1';
+import 'package:locus/src/version.dart';
 
 const _header = '''
 ╔══════════════════════════════════════════════════════════════╗
@@ -65,7 +64,7 @@ void main(List<String> args) async {
   }
 
   if (results['help'] as bool) {
-    stdout.writeln('Locus Setup Wizard v$_version');
+    stdout.writeln('Locus Setup Wizard v$locusVersion');
     stdout.writeln('');
     stdout.writeln(
       'Automatically configures Android and iOS platform files for Locus.',
@@ -78,7 +77,7 @@ void main(List<String> args) async {
   }
 
   if (results['version'] as bool) {
-    stdout.writeln(_version);
+    stdout.writeln(locusVersion);
     exit(0);
   }
 

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -20,7 +20,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:locus/src/cli/ios_permission_macros.dart';
 
-const _version = '2.4.0';
+const _version = '2.4.1';
 
 const _header = '''
 ╔══════════════════════════════════════════════════════════════╗

--- a/doc/guides/quickstart.md
+++ b/doc/guides/quickstart.md
@@ -8,7 +8,7 @@ Add `locus` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  locus: ^2.4.0
+  locus: ^2.4.1
 ```
 
 ## 2. Automated Setup

--- a/doc/setup/installation.md
+++ b/doc/setup/installation.md
@@ -6,7 +6,7 @@ Add Locus to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  locus: ^2.4.0
+  locus: ^2.4.1
 ```
 
 Or install via command line:

--- a/doc/setup/platform-specific.md
+++ b/doc/setup/platform-specific.md
@@ -19,9 +19,7 @@ Detailed iOS and Android setup instructions for the Locus SDK, including permiss
 - **Minimum SDK**: 26 (Android 8.0 Oreo)
 - **Target SDK**: Set by the host application; the Locus library does not override it
 - **Compile SDK**: 37+
-- **Gradle**: 9.5.0+
-- **Android Gradle Plugin**: 9.3.1+
-- **Kotlin**: 2.4.10+
+- **Gradle / Android Gradle Plugin / Kotlin**: Use the versions supplied by the consuming Flutter app
 - **Java**: 17+
 
 ### 1. AndroidManifest.xml Permissions
@@ -72,28 +70,10 @@ Add required permissions to `android/app/src/main/AndroidManifest.xml`:
 
 ### 2. Gradle Configuration
 
-**android/build.gradle.kts** (project-level):
-
-```kotlin
-buildscript {
-    ext.kotlin_version = '2.4.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:9.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-```
+Locus inherits the Android and Kotlin Gradle plugins from the consuming Flutter
+project. Keep the versions generated or recommended by your Flutter SDK. Do not
+add a separate Locus-specific plugin classpath: loading a second AGP or Kotlin
+plugin version can create incompatible Gradle classloaders.
 
 **android/app/build.gradle.kts** (app-level):
 
@@ -466,9 +446,9 @@ Fix issues based on output.
 
 | Component | Minimum Version | Recommended |
 |-----------|----------------|-------------|
-| Gradle | 9.5.0 | 9.5.0+ |
-| Android Gradle Plugin | 9.3.1 | 9.3.1+ |
-| Kotlin | 2.4.10 | 2.4.10+ |
+| Gradle | Host-controlled | Version supported by the host Flutter SDK |
+| Android Gradle Plugin | Host-controlled | Version supported by the host Flutter SDK |
+| Kotlin | Host-controlled | Version supported by the host Flutter SDK |
 | compileSdk | 37 | 37+ |
 | minSdk | 26 | 26+ |
 | targetSdk | Host-controlled | Host-controlled |
@@ -532,12 +512,14 @@ await Locus.requestPermission();
 
 #### Gradle build fails
 
-**Cause**: Version incompatibility.
+**Cause**: The host's Gradle, Android Gradle Plugin, and Kotlin versions are not
+compatible with its Flutter SDK, or a plugin-local classpath loads a second copy.
 
-**Solution**: Update Gradle and dependencies:
+**Solution**: Keep the versions generated or recommended by the host Flutter
+SDK, then check the project for compatibility guidance:
+
 ```bash
-cd android
-./gradlew wrapper --gradle-version 8.1
+flutter analyze --suggestions
 ```
 
 ### iOS Issues

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - locus (2.4.0):
+  - locus (2.4.1):
     - Flutter
   - permission_handler_apple (9.4.8):
     - Flutter
@@ -26,7 +26,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: 71a624a5bc0c04062bf19101d501e466baf2fb47
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  locus: 979306da1052da41cb49f087730f334b7a105428
+  locus: 0e41d18ef4ff0208a98b16800061452677a214f4
   permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
 
 PODFILE CHECKSUM: 768b4a918a83e6e6160609012b51a2f498d61a44

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -221,7 +221,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.4.1"
   logging:
     dependency: transitive
     description:

--- a/lib/src/config/geolocation_config.dart
+++ b/lib/src/config/geolocation_config.dart
@@ -243,7 +243,7 @@ class Config {
   }
 
   /// The current SDK version.
-  static const String version = '2.4.0';
+  static const String version = '2.4.1';
 
   // Location settings
   /// Desired location accuracy level.

--- a/lib/src/config/geolocation_config.dart
+++ b/lib/src/config/geolocation_config.dart
@@ -6,6 +6,7 @@ import 'package:locus/src/config/permission_rationale.dart';
 import 'package:locus/src/features/location/services/spoof_detection.dart'
     show SpoofDetectionConfig;
 import 'package:locus/src/models.dart';
+import 'package:locus/src/version.dart';
 
 /// Main configuration class for the background geolocation service.
 class Config {
@@ -243,7 +244,7 @@ class Config {
   }
 
   /// The current SDK version.
-  static const String version = '2.4.1';
+  static const String version = locusVersion;
 
   // Location settings
   /// Desired location accuracy level.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,3 @@
+/// Package version synchronized from `pubspec.yaml` by
+/// `tool/sync_version.dart`. Do not edit this value directly.
+const String locusVersion = '2.4.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,9 +2,9 @@ name: locus
 description: Core background geolocation SDK of the WeOrbis ecosystem for Flutter. Native tracking, geofencing, activity recognition, and sync.
 # Single source of truth for the SDK version. After bumping, run:
 #   dart run tool/sync_version.dart
-# to propagate to the Dart constants (lib/src/config/geolocation_config.dart,
-# bin/*.dart). Gradle (android/build.gradle.kts) and CocoaPods
-# (ios/locus.podspec) read this line directly at build time.
+# to propagate the shared Dart constant and current documentation. Gradle
+# (android/build.gradle.kts) and CocoaPods (ios/locus.podspec) read this line
+# directly at build time.
 version: 2.4.1
 homepage: https://github.com/weorbis/locus
 repository: https://github.com/weorbis/locus

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Core background geolocation SDK of the WeOrbis ecosystem for Flutte
 # to propagate to the Dart constants (lib/src/config/geolocation_config.dart,
 # bin/*.dart). Gradle (android/build.gradle.kts) and CocoaPods
 # (ios/locus.podspec) read this line directly at build time.
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/weorbis/locus
 repository: https://github.com/weorbis/locus
 issue_tracker: https://github.com/weorbis/locus/issues

--- a/test/unit/android_build_configuration_test.dart
+++ b/test/unit/android_build_configuration_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Android buildscript does not pin host plugin versions', () {
+    final buildScript = File('android/build.gradle.kts').readAsStringSync();
+
+    expect(
+      buildScript,
+      isNot(contains('com.android.tools.build:gradle:')),
+      reason:
+          'A plugin-local AGP copy creates incompatible Gradle classloaders.',
+    );
+    expect(
+      buildScript,
+      isNot(contains('org.jetbrains.kotlin:kotlin-gradle-plugin:')),
+      reason:
+          'A plugin-local Kotlin Gradle Plugin copy can diverge from the host.',
+    );
+  });
+}

--- a/test/unit/version_source_test.dart
+++ b/test/unit/version_source_test.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locus/locus.dart';
+import 'package:locus/src/version.dart';
+
+void main() {
+  test('current package version surfaces match pubspec.yaml', () {
+    final version = _pubspecVersion();
+
+    expect(locusVersion, version);
+    expect(Config.version, version);
+
+    final config = File(
+      'lib/src/config/geolocation_config.dart',
+    ).readAsStringSync();
+    expect(config, contains('static const String version = locusVersion;'));
+
+    for (final path in [
+      'bin/locus.dart',
+      'bin/setup.dart',
+      'bin/doctor.dart',
+    ]) {
+      final executable = File(path).readAsStringSync();
+      expect(executable, contains("import 'package:locus/src/version.dart';"));
+      expect(executable, isNot(contains('const _version =')));
+    }
+
+    final readme = File('README.md').readAsStringSync();
+    expect(readme, contains('  locus: ^$version'));
+    expect(readme, contains('- Current release: **v$version**'));
+    expect(
+      File('doc/guides/quickstart.md').readAsStringSync(),
+      contains('  locus: ^$version'),
+    );
+    expect(
+      File('doc/setup/installation.md').readAsStringSync(),
+      contains('  locus: ^$version'),
+    );
+
+    final androidBuild = File('android/build.gradle.kts').readAsStringSync();
+    expect(androidBuild, contains('file("../pubspec.yaml")'));
+
+    final podspec = File('ios/locus.podspec').readAsStringSync();
+    expect(
+      podspec,
+      contains("YAML.load_file(File.expand_path('../pubspec.yaml'"),
+    );
+    expect(podspec, contains("s.version          = pubspec['version']"));
+
+    final exampleLock = File('example/pubspec.lock').readAsStringSync();
+    expect(
+      _lockPackageSection(exampleLock, 'locus'),
+      contains('version: "$version"'),
+    );
+    expect(
+      File('example/ios/Podfile.lock').readAsStringSync(),
+      contains('- locus ($version):'),
+    );
+
+    final pipeline = File('.github/workflows/pipeline.yml').readAsStringSync();
+    expect(pipeline, contains("grep '^version:' pubspec.yaml"));
+  });
+
+  test('sync tool updates every generated surface and fails closed', () async {
+    final fixture = await Directory.systemTemp.createTemp(
+      'locus-version-sync-',
+    );
+    addTearDown(() => fixture.delete(recursive: true));
+
+    await _writeFixture(
+      fixture,
+      'pubspec.yaml',
+      'name: locus\nversion: 9.8.7\n',
+    );
+    await _writeFixture(
+      fixture,
+      'lib/src/version.dart',
+      "const String locusVersion = '0.0.0';\n",
+    );
+    await _writeFixture(
+      fixture,
+      'README.md',
+      'dependencies:\n  locus: ^0.0.0\n\n- Current release: **v0.0.0**\n',
+    );
+    await _writeFixture(
+      fixture,
+      'doc/guides/quickstart.md',
+      'dependencies:\n  locus: ^0.0.0\n',
+    );
+    await _writeFixture(
+      fixture,
+      'doc/setup/installation.md',
+      'dependencies:\n  locus: ^0.0.0\n',
+    );
+
+    final script = File('tool/sync_version.dart').absolute.path;
+    final stale = await _runSync(script, fixture, checkOnly: true);
+    expect(stale.exitCode, 1);
+
+    final updated = await _runSync(script, fixture);
+    expect(updated.exitCode, 0, reason: '${updated.stdout}\n${updated.stderr}');
+    expect(
+      File('${fixture.path}/lib/src/version.dart').readAsStringSync(),
+      contains("locusVersion = '9.8.7'"),
+    );
+    expect(
+      File('${fixture.path}/README.md').readAsStringSync(),
+      allOf(contains('locus: ^9.8.7'), contains('release: **v9.8.7**')),
+    );
+
+    final clean = await _runSync(script, fixture, checkOnly: true);
+    expect(clean.exitCode, 0, reason: '${clean.stdout}\n${clean.stderr}');
+
+    await File('${fixture.path}/doc/setup/installation.md').delete();
+    final missing = await _runSync(script, fixture, checkOnly: true);
+    expect(missing.exitCode, 2);
+    expect(missing.stderr, contains('version sync incomplete'));
+  });
+}
+
+String _pubspecVersion() {
+  final pubspec = File('pubspec.yaml').readAsStringSync();
+  return RegExp(
+    r'^version:\s*(\S+)',
+    multiLine: true,
+  ).firstMatch(pubspec)!.group(1)!;
+}
+
+String _lockPackageSection(String lockfile, String packageName) {
+  final section = RegExp(
+    '^  ${RegExp.escape(packageName)}:\\n(?:    .*\\n?)*',
+    multiLine: true,
+  ).firstMatch(lockfile);
+  expect(
+    section,
+    isNotNull,
+    reason: '$packageName is absent from pubspec.lock',
+  );
+  return section!.group(0)!;
+}
+
+Future<void> _writeFixture(
+  Directory root,
+  String relativePath,
+  String content,
+) async {
+  final file = File('${root.path}/$relativePath');
+  await file.parent.create(recursive: true);
+  await file.writeAsString(content);
+}
+
+Future<ProcessResult> _runSync(
+  String script,
+  Directory workingDirectory, {
+  bool checkOnly = false,
+}) {
+  return Process.run('dart', [
+    script,
+    if (checkOnly) '--check',
+  ], workingDirectory: workingDirectory.path);
+}

--- a/tool/sync_version.dart
+++ b/tool/sync_version.dart
@@ -1,5 +1,5 @@
-// Propagates pubspec.yaml's `version:` to the Dart constants the SDK
-// exposes to host apps and CLI tools.
+// Propagates pubspec.yaml's `version:` to the generated Dart constant and
+// current-version documentation surfaces.
 //
 // Native build files (android/build.gradle.kts, ios/locus.podspec) read
 // pubspec.yaml directly at build time, so they're not listed here. CI
@@ -27,31 +27,37 @@ void main(List<String> args) {
     exit(2);
   }
 
-  // Each target is a (path, regex-with-2-capturing-groups). The version
+  // Each target is a (path, regex-with-3-capturing-groups). The version
   // string sits between the two captures. Updating preserves whatever
   // prefix/suffix surrounds it (single quotes, spaces, etc.) so the file
   // diff stays minimal and readable.
+  final dependencyVersionPattern = RegExp(
+    r'(  locus: \^)(\S+)([ \t]*$)',
+    multiLine: true,
+  );
   final targets = <_Target>[
     _Target.line(
-      path: 'lib/src/config/geolocation_config.dart',
-      pattern: RegExp(r"(static const String version = ')([^']+)(';)"),
+      path: 'lib/src/version.dart',
+      pattern: RegExp(r"(const String locusVersion = ')([^']+)(';)"),
+    ),
+    _Target.line(path: 'README.md', pattern: dependencyVersionPattern),
+    _Target.line(
+      path: 'README.md',
+      pattern: RegExp(r'(- Current release: \*\*v)([^*]+)(\*\*)'),
     ),
     _Target.line(
-      path: 'bin/doctor.dart',
-      pattern: RegExp(r"(const _version = ')([^']+)(';)"),
+      path: 'doc/guides/quickstart.md',
+      pattern: dependencyVersionPattern,
     ),
     _Target.line(
-      path: 'bin/setup.dart',
-      pattern: RegExp(r"(const _version = ')([^']+)(';)"),
-    ),
-    _Target.line(
-      path: 'bin/locus.dart',
-      pattern: RegExp(r"(const _version = ')([^']+)(';)"),
+      path: 'doc/setup/installation.md',
+      pattern: dependencyVersionPattern,
     ),
   ];
 
   var stale = 0;
   var written = 0;
+  var missing = 0;
   for (final target in targets) {
     final result = target.apply(version, checkOnly: checkOnly);
     switch (result) {
@@ -66,7 +72,15 @@ void main(List<String> args) {
         written++;
       case _Outcome.missing:
         stderr.writeln('  missing: ${target.path} (skipped)');
+        missing++;
     }
+  }
+
+  if (missing > 0) {
+    stderr.writeln(
+      '$missing target(s) missing or unmatched; version sync incomplete.',
+    );
+    exit(2);
   }
 
   if (checkOnly) {


### PR DESCRIPTION
## Description

Prepare Locus v2.4.1 with the durable Android Gradle compatibility fix for #57. The plugin now inherits the host application's Android Gradle and Kotlin plugins instead of loading private copies that can fail across classloaders.

This release also includes the immediate-sync payload fix merged in #56.

Closes #57.
Supersedes #58.

## Release Outputs

- Version: `2.4.1`
- Changelog: [`CHANGELOG.md`](CHANGELOG.md)
- Production approval: required from `The-PatientZero` after this PR merges and the `main` pipeline passes
- Tag: `v2.4.1`, created by the approved release workflow
- GitHub Release: generated automatically from `v2.4.1` by the same workflow
- pub.dev: published manually only after the tag and GitHub Release are verified

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore / Documentation / Refactor

## Native Changes

- [x] Android (Java/Gradle)
- [ ] iOS (Swift/Podspec)
- [ ] Dart/Flutter only

## Testing Checklist

- [x] `flutter analyze` passes
- [x] `flutter test` passes (795 tests)
- [x] `cd example && flutter build apk --debug` (Android Build)
- [x] iOS CocoaPods and SwiftPM build gates pass
- [ ] Verified on physical device (not required for this build-system release fix)

Additional release verification:

- [x] Android unit tests pass (68 tests)
- [x] Android lint and instrumentation APK assembly pass
- [x] Dart formatting and version synchronization pass
- [x] Version-source regression tests cover Dart/CLI, docs, native metadata, lockfiles, and release automation
- [x] Pana score is 160/160
- [x] pub.dev dry-run passes: 772 KB, zero warnings

## Screenshots / Diagnostics

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented code where additional context is required.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] The dependent #56 change has been merged into `main`.
